### PR TITLE
Use prefix(upTo:) and suffix(from:) 

### DIFF
--- a/Sources/Middlewares/LoggerMiddleware/LoggerMiddleware.swift
+++ b/Sources/Middlewares/LoggerMiddleware/LoggerMiddleware.swift
@@ -200,8 +200,8 @@ enum LoggingParts {
         break
       } else {
         let index = restOfString.index(restOfString.startIndex, offsetBy: lineLength)
-        let stringPart = restOfString.substring(to: index)
-        restOfString = restOfString.substring(from: index)
+        let stringPart = restOfString.prefix(upTo: index)
+        restOfString = String(restOfString.suffix(from: index))
         
         parts.append(prefixPart + stringPart)
       }


### PR DESCRIPTION
These methods are not deprecated in Swift 4. Please see the images below as to what these warnings are.
![screen shot 2017-10-24 at 10 18 24 am](https://user-images.githubusercontent.com/5828780/31933668-082219f2-b8aa-11e7-942f-e67fcc6ca68b.png)
![screen shot 2017-10-24 at 10 18 50 am](https://user-images.githubusercontent.com/5828780/31933678-0f995998-b8aa-11e7-9539-2f1e26760d2b.png)

