### PR TITLE
Add a bool flag to disable debug logging

### DIFF
--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -39,9 +39,11 @@ typealias CallbackId = String
 extension Suas {
   // For testing
   static var fatalErrorHandler: (() -> ())? = nil
+  static var enableDebugLogging: Bool = true
 
   static func log(_ string: @autoclosure () -> String) {
     #if DEBUG
+      if !enableDebugLogging { return }
       print("🔼 Suas: \(string())")
     #endif
   }


### PR DESCRIPTION
Add a bool flag to disable debug logging. During development the console is spammed and important Xcode debug logs can be missed because of the large volume of logs generated by Suas.