### PR TITLE
Make enableDebugLogging public

### DIFF
--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -39,7 +39,9 @@ typealias CallbackId = String
 extension Suas {
   // For testing
   static var fatalErrorHandler: (() -> ())? = nil
-  static var enableDebugLogging: Bool = true
+    
+  /// A boolean flag to disable debug logging. Defaults to true.
+  public static var enableDebugLogging: Bool = true
 
   static func log(_ string: @autoclosure () -> String) {
     #if DEBUG

--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -40,7 +40,7 @@ extension Suas {
   // For testing
   static var fatalErrorHandler: (() -> ())? = nil
     
-  /// A boolean flag to disable debug logging. Defaults to true.
+  /// A boolean flag to enable debug logging. Defaults to true.
   public static var enableDebugLogging: Bool = true
 
   static func log(_ string: @autoclosure () -> String) {


### PR DESCRIPTION
Make enableDebugLogging public so that non-internal components can access it too. Add a description to explain to API users what it does.

We might want to scope this differently. At the moment, you access it like:
Suas.enableDebugLogging , but I don't know if this fits?