### PR TITLE
Updated Common to disable logging by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ xcuserdata
 SampleApps/TodoSampleApp/Pods/
 SampleApps/TodoWithMonitorSampleApp/Pods/
 vendor/
+Index
+IDEWorkspaceChecks.plist

--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 
+
 /// Store state is stored as a Dictionary of [StateKey: Any]
 public typealias StateKey = String
 
@@ -40,8 +41,8 @@ extension Suas {
   // For testing
   static var fatalErrorHandler: (() -> ())? = nil
     
-  /// A boolean flag to enable debug logging. Defaults to true.
-  public static var enableDebugLogging: Bool = true
+  /// A boolean flag to enable debug logging. Defaults to false.
+  public static var enableDebugLogging: Bool = false
 
   static func log(_ string: @autoclosure () -> String) {
     #if DEBUG

--- a/Tests/ListenerTests.swift
+++ b/Tests/ListenerTests.swift
@@ -10,7 +10,11 @@ import XCTest
 @testable import Suas
 
 class ListenerTests: XCTestCase {
-  
+
+    override func setUp() {
+        Suas.enableDebugLogging = true
+    }
+
   func testItCanListenToAChange() {
     let store = Suas.createStore(reducer: reducer1)
     

--- a/Tests/ReducerTests.swift
+++ b/Tests/ReducerTests.swift
@@ -10,6 +10,11 @@ import XCTest
 @testable import Suas
 
 class ReducerTests: XCTestCase {
+
+    override func setUp() {
+        Suas.enableDebugLogging = true
+    }
+
   func testItReducesWithABlockWithState() {
     let state = MyState1(value: 0)
     let newState = reducer1.reduce(state: state, action: IncrementAction())

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -11,6 +11,10 @@ import XCTest
 
 class StoreTests: XCTestCase {
 
+    override func setUp() {
+        Suas.enableDebugLogging = true
+    }
+
   func testItCanGetTheFullState() {
     let store = Suas.createStore(reducer: Reducer1() + Reducer2())
 


### PR DESCRIPTION
Updated the default behavior of the logger to be disabled by default. Feels like this makes more sense. Suas can generate a **lot** of logs, so rather than on everywhere and selectively turning off, I think off everywhere and selectively turning on makes more sense. 

Also updated gitignore to avoid checking in index directory and workspace checks plist. 